### PR TITLE
Use the default method (i.e. GET) to open the data stream.

### DIFF
--- a/Sources/UrsusHTTP/Client.swift
+++ b/Sources/UrsusHTTP/Client.swift
@@ -45,7 +45,7 @@ public class Client {
 extension Client {
     
     @discardableResult public func connect() -> DataStreamRequest {
-        eventSource = eventSource ?? session.eventSourceRequest(channelURL(uid: eventSourceUID), method: .put, lastEventID: String(eventID))
+        eventSource = eventSource ?? session.eventSourceRequest(channelURL(uid: eventSourceUID), lastEventID: String(eventID))
             .validate()
             .responseDecodableEventSource(using: DecodableEventSourceSerializer<Response>(decoder: ClientJSONDecoder())) { [weak self] eventSource in
                 switch eventSource.event {


### PR DESCRIPTION
To open a stream from the Urbit ship, we need to do a GET request, not a PUT request.

There's a related issue with AlamofireEventSource.  The `eventSourceRequest` function is not actually doing anything with the `method` parameter.  So, this was working in spite of this, only because it was ignoring the PUT we passed in and doing the default GET. 

I'd do a PR on that, but I'm not 100% sure how AlamofireEventSource works.